### PR TITLE
Removed vestigial Python 2 things.

### DIFF
--- a/gobsprogram.py3
+++ b/gobsprogram.py3
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-from __future__ import print_function
+#!/usr/bin/env python3
 from colorama import init
 
 


### PR DESCRIPTION
obviously `print_function` from `__future__` isn't needed if you're in python3, it _is_ the future

![](http://i.imgur.com/rAq8ktb.gif)
